### PR TITLE
Use github actions for CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,12 +2,12 @@
 branch = True
 source = flake8_nb/*
 include = flake8_nb/*
-#          tests/*
-# uncomment the above line if you want to see if all tests did run
 omit = setup.py
        flake8_nb/__init__.py
        flake8_nb/*/__init__.py
        tests/__init__.py
+       */tests/*
+# uncomment the above line if you want to see if all tests did run
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
-#include = flake8_nb/*
+source = flake8_nb/*
+include = flake8_nb/*
 #          tests/*
 # uncomment the above line if you want to see if all tests did run
 omit = setup.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,127 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - "releases/*"
+
+jobs:
+  flake8:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Lint with flake8
+        run: |
+          flake8 flake8_nb tests
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup conda
+        uses: s-weigand/setup-conda@master
+        with:
+          conda-channels: conda-forge
+      - name: Install dependencies
+        run: |
+          conda install -y tox pandoc
+          pip freeze
+          pandoc -v
+      - name: Build docs
+        run: tox -e docs
+
+  docs-link:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup conda
+        uses: s-weigand/setup-conda@master
+        with:
+          conda-channels: conda-forge
+      - name: Install dependencies
+        run: |
+          conda install -y tox pandoc
+          pip freeze
+          pandoc -v
+      - name: Build docs
+        run: tox -e docs-links
+
+  flake8-nightly:
+    runs-on: ubuntu-latest
+    needs: [flake8, docs]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U .
+          python -m pip install -U -c constraints.txt -r requirements_dev.txt
+          python -m pip install -U -q git+https://gitlab.com/pycqa/flake8.git
+      - name: Run tests
+        env:
+          TOX_ENV_NAME: flake8-nightly
+        run: |
+          py.test --cov=flake8_nb --cov-append --cov-config .coveragerc tests
+
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: [flake8, docs]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U .
+          python -m pip install -U -c constraints.txt -r requirements_dev.txt
+      - name: Run tests
+        run: |
+          py.test --cov=flake8_nb --cov-append --cov-config .coveragerc tests
+
+  deploy:
+    runs-on: [ubuntu-latest]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: [test, flake8-nightly]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U -c constraints.txt -r requirements_dev.txt
+          pip install -U .
+      - name: Build dist
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,5 @@
 name: "Test"
-on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - "releases/*"
+on: [push, pull_request]
 
 jobs:
   flake8:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,14 +63,19 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U .
+          python -m pip install -U -e .
           python -m pip install -U -c constraints.txt -r requirements_dev.txt
           python -m pip install -U -q git+https://gitlab.com/pycqa/flake8.git
       - name: Run tests
         env:
           TOX_ENV_NAME: flake8-nightly
         run: |
-          py.test --cov=flake8_nb --cov-append --cov-config .coveragerc tests
+          py.test --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./coverage.xml
 
   test:
     runs-on: ${{ matrix.os }}
@@ -90,11 +95,16 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U .
+          python -m pip install -U -e .
           python -m pip install -U -c constraints.txt -r requirements_dev.txt
       - name: Run tests
         run: |
-          py.test --cov=flake8_nb --cov-append --cov-config .coveragerc tests
+          py.test --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./coverage.xml
 
   deploy:
     runs-on: [ubuntu-latest]

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Supported Python Versions](https://img.shields.io/pypi/pyversions/flake8_nb.svg)](https://pypi.org/project/flake8-nb/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-[![Test Status Linux and OsX](https://api.travis-ci.org/s-weigand/flake8-nb.svg?branch=master)](https://travis-ci.org/s-weigand/flake8-nb)
-[![Test Status Windows](https://ci.appveyor.com/api/projects/status/gf2hgt9p2vb8y08y/branch/master?svg=true)](https://ci.appveyor.com/project/s-weigand/flake8-nb/branch/master)
+[![Actions Status](https://github.com/s-weigand/flake8-nb/workflows/test/badge.svg)](https://github.com/s-weigand/flake8-nb/actions)
 [![Documentation Status](https://readthedocs.org/projects/flake8-nb/badge/?version=latest)](https://flake8-nb.readthedocs.io/en/latest/?badge=latest)
 [![Test Coverage](https://coveralls.io/repos/github/s-weigand/flake8-nb/badge.svg?branch=master)](https://coveralls.io/github/s-weigand/flake8-nb?branch=master)
 [![Updates](https://pyup.io/repos/github/s-weigand/flake8-nb/shield.svg)](https://pyup.io/repos/github/s-weigand/flake8-nb/)


### PR DESCRIPTION
This PR exchanges travis and appveyor, for github actions to run CI and CD.
It also exchanges coveralls.io for codecov.io, for coverage reporting.