### PR TITLE
Adapt to nightly flake8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Code style Python: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/s-weigand/flake8-nb.git/master?urlpath=lab%2Ftree%2Ftests%2Fdata%2Fnotebooks)
 
-`flake8` checking for jupyter notebooks.
+[`flake8`](https://gitlab.com/pycqa/flake8) checking for jupyter notebooks.
 Basically this is a hack on the `flake8`'s `Application` class,
 which adds parsing and a cell based formatter for `*.ipynb` files.
 

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -221,7 +221,11 @@ class Flake8NbApplication(Application):
         )
 
     def parse_configuration_and_cli_nightly(
-        self, config_finder: config.ConfigFileFinder, argv: Optional[List[str]] = None
+        self,
+        config_finder: config.ConfigFileFinder,
+        config_file: Optional[str],
+        ignore_config_files: bool,
+        argv: Optional[List[str]] = None,
     ) -> None:
         """
         Compat version of self.parse_configuration_and_cli to work with nightly
@@ -230,16 +234,20 @@ class Flake8NbApplication(Application):
 
         Parse configuration files and the CLI options.
 
-        Parameters
-        ----------
-        config_finder: config.ConfigFileFinder
-        argv: List[str]
+        :param config.ConfigFileFinder config_finder:
+            The finder for finding and reading configuration files.
+        :param str config_file:
+            The optional configuraiton file to override all other configuration
+            files (i.e., the --config option).
+        :param bool ignore_config_files:
+            Determine whether to parse configuration files or not. (i.e., the
+            --isolated option).
+        :param list argv:
             Command-line arguments passed in directly.
         """
-        if self.options is None and self.args is None:  # pragma: no branch
-            self.options, self.args = aggregator.aggregate_options(
-                self.option_manager, config_finder, argv
-            )
+        self.options, self.args = aggregator.aggregate_options(
+            self.option_manager, config_finder, config_file, ignore_config_files, argv,
+        )
 
         self.args = self.hack_args(self.args)
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 with open("HISTORY.md", encoding="utf-8") as history_file:
     history = history_file.read()
 
-requirements = ["flake8>=3.0.0", "nbconvert>=5.6.0", "ipython>=7.8.0"]
+requirements = ["flake8>=3.0.0,<3.8.0", "nbconvert>=5.6.0", "ipython>=7.8.0"]
 
 
 setup_requirements = ["pytest-runner"]


### PR DESCRIPTION
Fixes an issue caused by changes of the inner workings of `flake8`'s `Application` class and set the current version of `flake8` (`3.7.9`) as max version in `setup.py`.