### PR TITLE
Change flake8 version extraction

### DIFF
--- a/.github/workflows/test-nightly-schedule.yml
+++ b/.github/workflows/test-nightly-schedule.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
+        env:
+          TOX_ENV_NAME: flake8-nightly
         run: |
           python -m pip install -U pip
           python -m pip install -U -c constraints.txt -r requirements_dev.txt
           python -m pip install -U -q git+https://gitlab.com/pycqa/flake8.git
       - name: Run tests
-        env:
-          TOX_ENV_NAME: flake8-nightly
         run: |
           py.test -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,13 +68,13 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
+        env:
+          TOX_ENV_NAME: flake8-nightly
         run: |
           python -m pip install -U pip
           python -m pip install -U -c constraints.txt -r requirements_dev.txt
           python -m pip install -U -q git+https://gitlab.com/pycqa/flake8.git
       - name: Run tests
-        env:
-          TOX_ENV_NAME: flake8-nightly
         run: |
           py.test -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
       - name: Codecov Upload

--- a/flake8_nb/__init__.py
+++ b/flake8_nb/__init__.py
@@ -14,7 +14,29 @@ from .flake8_integration.formatter import IpynbFormatter  # noqa: F401
 
 __all__ = "IpynbFormatter"
 
-FLAKE8_VERSION_TUPLE = tuple(map(int, flake8.__version__.split(".")))
+
+def save_cast_int(int_str: str) -> int:
+    """
+    Helper function so the version number of prereleases (i.e. 3.8.0rc1)
+    does not throw exceptions
+
+    Parameters
+    ----------
+    int_str : str
+        String which should represent a number.
+
+    Returns
+    -------
+    int
+        Int representation of int_str
+    """
+    try:
+        return int(int_str)
+    except ValueError:
+        return 0
+
+
+FLAKE8_VERSION_TUPLE = tuple(map(save_cast_int, flake8.__version__.split(".")))
 
 # this is yet another hack, since the flake8 master still has
 # the same version string as the latest PyPi release

--- a/flake8_nb/__init__.py
+++ b/flake8_nb/__init__.py
@@ -6,8 +6,6 @@ __author__ = """Sebastian Weigand"""
 __email__ = "s.weigand.phy@gmail.com"
 __version__ = "0.1.4"
 
-import os
-
 import flake8
 
 from .flake8_integration.formatter import IpynbFormatter  # noqa: F401
@@ -37,9 +35,3 @@ def save_cast_int(int_str: str) -> int:
 
 
 FLAKE8_VERSION_TUPLE = tuple(map(save_cast_int, flake8.__version__.split(".")))
-
-# this is yet another hack, since the flake8 master still has
-# the same version string as the latest PyPi release
-tox_env_name = os.environ.get("TOX_ENV_NAME", None)
-if tox_env_name and tox_env_name == "flake8-nightly":
-    FLAKE8_VERSION_TUPLE = (3, 8, 0)

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ with open("HISTORY.md", encoding="utf-8") as history_file:
 
 requirements = ["flake8>=3.0.0,<3.8.0", "nbconvert>=5.6.0", "ipython>=7.8.0"]
 
+# This is a hack to test against the flake8 master branch
+tox_env_name = os.environ.get("TOX_ENV_NAME", None)
+if tox_env_name and tox_env_name == "flake8-nightly":
+    requirements[0] = "flake8>=3.0.0"
 
 setup_requirements = ["pytest-runner"]
 

--- a/tests/flake8_integration/test_cli.py
+++ b/tests/flake8_integration/test_cli.py
@@ -16,7 +16,9 @@ from .conftest import TempIpynbArgs
 
 def test_get_notebooks_from_args(temp_ipynb_args: TempIpynbArgs):
     orig_args, (expected_args, expected_nb_list) = temp_ipynb_args.get_args_and_result()
-    args, nb_list = get_notebooks_from_args(orig_args)
+    args, nb_list = get_notebooks_from_args(
+        orig_args, exclude=["*.tox/*", "*.ipynb_checkpoints*", "*/docs/*"]
+    )
     assert sorted(args) == sorted(expected_args)
     assert sorted(nb_list) == sorted(expected_nb_list)
 

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,8 @@ commands_pre =
   {[testenv]commands_pre}
   {envpython} -m pip install -U -q git+https://gitlab.com/pycqa/flake8.git
 commands =
-  py.test -vv --cov=flake8_nb --cov-append --cov-config .coveragerc tests
   {envpython}  -c "import flake8_nb;print('FLAKE8 VERSION: ', flake8_nb.FLAKE8_VERSION_TUPLE)"
+  py.test -vv --cov=flake8_nb --cov-append --cov-config .coveragerc tests
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Since flake8 changed its version on master to `3.8.0.a2` the version extraction did break and nightly-tests did fail. This PR fixes the issues.
- Flake8 version extraction is now more robust and won't raise an exception.
- The hack to test flake8 master branch was moved from `flake8_nb.__init__` to the setup, so the requirements won't conflict. This also required that the envvar `TOX_ENV_NAME: flake8-nightly` is set at the installation and not at test step.
- The docs folder was excluded from `test_get_notebooks_from_args`, since the test would either fail for users who haven't built the doc or for those who have.
