### PR TITLE
Adapt to changes in codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Codecov Upload
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
           name: flake8-nightly
 
@@ -108,7 +107,6 @@ jobs:
       - name: Codecov Upload
         uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml
           name: ${{ matrix.os }}-py${{ matrix.python-version }}
 


### PR DESCRIPTION
- `continue-on-error` was deprecated
- `token` isn't needed anymore for public repos and dropping it allows codcov upload from fork PRs