### PR TITLE
Fix exclude not working

### DIFF
--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -170,7 +170,7 @@ class Flake8NbApplication(Application):
         )
 
     @staticmethod
-    def hack_args(args: List[str]) -> List[str]:
+    def hack_args(args: List[str], exclude: List[str]) -> List[str]:
         r"""
         Checks the passed args if ``*.ipynb`` can be found and
         appends intermediate parsed files to the list of files,
@@ -180,6 +180,8 @@ class Flake8NbApplication(Application):
         ----------
         args : List[str]
             List of commandline arguments provided to ``flake8_nb``
+        exclude : List[str]
+            File-/Folderpatterns that should be excluded
 
         Returns
         -------
@@ -187,7 +189,7 @@ class Flake8NbApplication(Application):
             The original args + intermediate parsed ``*.ipynb`` files.
         """
 
-        args, nb_list = get_notebooks_from_args(args)
+        args, nb_list = get_notebooks_from_args(args, exclude=exclude)
         notebook_parser = NotebookParser(nb_list)
         return args + notebook_parser.intermediate_py_file_paths
 
@@ -205,7 +207,7 @@ class Flake8NbApplication(Application):
                 self.option_manager, self.config_finder, argv
             )
 
-        self.args = self.hack_args(self.args)
+        self.args = self.hack_args(self.args, self.options.exclude)
 
         self.running_against_diff = self.options.diff
         if self.running_against_diff:  # pragma: no cover
@@ -239,7 +241,7 @@ class Flake8NbApplication(Application):
             self.option_manager, config_finder, argv,
         )
 
-        self.args = self.hack_args(self.args)
+        self.args = self.hack_args(self.args, self.options.exclude)
 
         self.running_against_diff = self.options.diff
         if self.running_against_diff:  # pragma: no cover

--- a/tests/flake8_integration/test_cli.py
+++ b/tests/flake8_integration/test_cli.py
@@ -48,7 +48,9 @@ def test_Flake8NbApplication__option_defaults():
 @pytest.mark.filterwarnings(InvalidNotebookWarning)
 def test_Flake8NbApplication__hack_args(temp_ipynb_args: TempIpynbArgs):
     orig_args, (expected_args, _) = temp_ipynb_args.get_args_and_result()
-    result = Flake8NbApplication.hack_args(orig_args)
+    result = Flake8NbApplication.hack_args(
+        orig_args, exclude=["*.tox/*", "*.ipynb_checkpoints*", "*/docs/*"]
+    )
     expected_parsed_nb_list = NotebookParser.intermediate_py_file_paths
 
     assert result == expected_args + expected_parsed_nb_list

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -40,6 +40,22 @@ def test_run_main(capsys, keep_intermediate: bool):
         NotebookParser.clean_up()
 
 
+def test_run_main_all_excluded(capsys):
+    argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
+    argv += [
+        "--exclude",
+        f"*.tox/*,*.ipynb_checkpoints*,*/docs/*,{TEST_NOTEBOOK_BASE_PATH}",
+    ]
+    with pytest.raises(SystemExit):
+        with pytest.warns(InvalidNotebookWarning):
+            main(argv)
+    captured = capsys.readouterr()
+    result_output = captured.out
+    result_list = result_output.replace("\r", "").split("\n")
+    result_list.remove("")
+    assert len(result_list) == 0
+
+
 @pytest.mark.parametrize("keep_intermediate", [True, False])
 @pytest.mark.parametrize("cli_entrypoint", ["flake8_nb", "flake8-nb"])
 def test_syscall(cli_entrypoint: str, keep_intermediate: bool):

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -16,6 +16,7 @@ def test_run_main(capsys, keep_intermediate: bool):
     argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
     if keep_intermediate:
         argv.append("--keep-parsed-notebooks")
+    argv += ["--exclude", "*.tox/*,*.ipynb_checkpoints*,*/docs/*"]
     with pytest.raises(SystemExit):
         with pytest.warns(InvalidNotebookWarning):
             main(argv)
@@ -45,6 +46,7 @@ def test_syscall(cli_entrypoint: str, keep_intermediate: bool):
     argv = [cli_entrypoint, TEST_NOTEBOOK_BASE_PATH]
     if keep_intermediate:
         argv.append("--keep-parsed-notebooks")
+    argv += ["--exclude", "*.tox/*,*.ipynb_checkpoints*,*/docs/*"]
     proc = subprocess.Popen(argv, stdout=subprocess.PIPE, universal_newlines=True)
     result_list = []
     for line in proc.stdout:


### PR DESCRIPTION
This PR fixes the issue that the `--exclude` option wasn't working (see #29 ).
This was a result of the exclude pattern not being passed to notebook collector, when hacking the args.