### PR TITLE
Test flake8 minversion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,30 @@ jobs:
           file: ./coverage.xml
           name: flake8-nightly
 
+  flake8-legacy:
+    runs-on: ubuntu-latest
+    needs: [flake8, docs]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U -c constraints.txt -r requirements_dev.txt
+          python -m pip install -U -q 'flake8==3.7.0'
+      - name: Run tests
+        run: |
+          py.test -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+      - name: Codecov Upload
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          name: flake8-legacy
+
   test:
     runs-on: ${{ matrix.os }}
     needs: [flake8, docs]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", encoding="utf-8") as readme_file:
 with open("HISTORY.md", encoding="utf-8") as history_file:
     history = history_file.read()
 
-requirements = ["flake8>=3.0.0,<3.8.0", "nbconvert>=5.6.0", "ipython>=7.8.0"]
+requirements = ["flake8>=3.7.0,<3.8.0", "nbconvert>=5.6.0", "ipython>=7.8.0"]
 
 # This is a hack to test against the flake8 master branch
 tox_env_name = os.environ.get("TOX_ENV_NAME", None)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.4.0
-envlist = py{36,37,38}, flake8-nightly, flake8, docs, docs-links
+envlist = py{36,37,38}, flake8-nightly, flake8-legacy, flake8, docs, docs-links
 
 
 [flake8]
@@ -45,6 +45,14 @@ commands_pre =
 commands =
   {envpython}  -c "import flake8_nb;print('FLAKE8 VERSION: ', flake8_nb.FLAKE8_VERSION_TUPLE)"
   py.test -vv --cov=flake8_nb --cov-append --cov-config .coveragerc tests
+
+[testenv:flake8-legacy]
+passenv = *
+commands_pre =
+  {[testenv]commands_pre}
+  {envpython} -m pip install -U -q 'flake8==3.7.0'
+commands =
+  {[testenv:flake8-nightly]commands}
 
 [testenv]
 passenv = *


### PR DESCRIPTION
- Add tests for legacy `flake8` version
- Sets the prpoper install requirement of `flake8` to version `3.7.0`