### PR TITLE
Fix argv behavior for flake8>3.7.9, when main is called directly (tests)

### DIFF
--- a/flake8_nb/__main__.py
+++ b/flake8_nb/__main__.py
@@ -26,6 +26,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     if FLAKE8_VERSION_TUPLE > (3, 7, 9):  # pragma: no cover
         if argv is None:
             argv = sys.argv[1:]
+        else:
+            argv = argv[1:]
 
     app = Flake8NbApplication()
     app.run(argv)


### PR DESCRIPTION
Fixed argv striping of first arg when flake8>3.7.9 .
This did lead to failing tests, when publishing on conda-forge, but doesn't change the behavior.