### PR TITLE
Refactor

### DIFF
--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -87,7 +87,9 @@ class Flake8NbApplication(Application):
             help="Keep the temporary parsed notebooks, i.e. for debugging.",
         )
         if FLAKE8_VERSION_TUPLE > (3, 7, 9):
-            self.parse_configuration_and_cli = self.parse_configuration_and_cli_nightly
+            self.parse_configuration_and_cli = (  # type: ignore
+                self.parse_configuration_and_cli_nightly
+            )
 
     def hack_flake8_program_and_version(self, program: str, version: str) -> None:
         """
@@ -101,12 +103,10 @@ class Flake8NbApplication(Application):
         version : str
             Version of the program
         """
-        # TODO Cleanup after flake8>3.7.8 release
-        # if https://gitlab.com/pycqa/flake8/merge_requests/359#note_226407899 gets merged
         self.program = program
         self.version = version
         self.option_manager.parser.prog = program
-        self.option_manager.parser.version = version
+        self.option_manager.parser.version = version  # type: ignore
         self.option_manager.program_name = program
         self.option_manager.version = version
 
@@ -132,11 +132,11 @@ class Flake8NbApplication(Application):
                 for index, action in enumerate(parser._actions):  # pragma: no branch
                     if long_option_name in action.option_strings:
                         parser._handle_conflict_resolve(
-                            None, [(long_option_name, parser._actions[index])]
+                            None, [(long_option_name, parser._actions[index])]  # type: ignore
                         )
                         break
             else:
-                parser.remove_option(long_option_name)
+                parser.remove_option(long_option_name)  # type: ignore
         self.option_manager.add_option(long_option_name, *args, **kwargs)
 
     def hack_options(self) -> None:
@@ -166,8 +166,7 @@ class Flake8NbApplication(Application):
             comma_separated_list=True,
             parse_from_config=True,
             normalize_paths=True,
-            help="Comma-separated list of files or directories to exclude."
-            " (Default: %default)",
+            help="Comma-separated list of files or directories to exclude." " (Default: %default)",
         )
 
     @staticmethod
@@ -196,6 +195,8 @@ class Flake8NbApplication(Application):
 
     def parse_configuration_and_cli(self, argv: Optional[List[str]] = None) -> None:
         """
+        Compat version of self.parse_configuration_and_cli to work with flake8 >=3.7.0,<= 3.7.9
+
         Parse configuration files and the CLI options.
 
         Parameters
@@ -205,7 +206,7 @@ class Flake8NbApplication(Application):
         """
         if self.options is None and self.args is None:  # pragma: no branch
             self.options, self.args = aggregator.aggregate_options(
-                self.option_manager, self.config_finder, argv
+                self.option_manager, self.config_finder, argv  # type: ignore
             )
 
         self.args = self.hack_args(self.args, self.options.exclude)
@@ -219,16 +220,13 @@ class Flake8NbApplication(Application):
         self.options._running_from_vcs = False
 
         self.check_plugins.provide_options(self.option_manager, self.options, self.args)
-        self.formatting_plugins.provide_options(
-            self.option_manager, self.options, self.args
-        )
+        self.formatting_plugins.provide_options(self.option_manager, self.options, self.args)
 
     def parse_configuration_and_cli_nightly(
         self, config_finder: config.ConfigFileFinder, argv: List[str]
     ) -> None:
         """
-        Compat version of self.parse_configuration_and_cli to work with nightly
-        build of flake8 master
+        Compat version of self.parse_configuration_and_cli to work with flake8 > 3.7.9 and master
         https://gitlab.com/pycqa/flake8/blob/master/src/flake8/main/application.py#L194
 
         Parse configuration files and the CLI options.
@@ -253,9 +251,7 @@ class Flake8NbApplication(Application):
         self.options._running_from_vcs = False
 
         self.check_plugins.provide_options(self.option_manager, self.options, self.args)
-        self.formatting_plugins.provide_options(
-            self.option_manager, self.options, self.args
-        )
+        self.formatting_plugins.provide_options(self.option_manager, self.options, self.args)
 
     def exit(self) -> None:
         """Handle finalization and exiting the program.
@@ -266,8 +262,7 @@ class Flake8NbApplication(Application):
         if self.options.keep_parsed_notebooks:
             temp_path = NotebookParser.temp_path
             print(
-                f"The parsed notebooks, are still present at:\n\t{temp_path}",
-                file=sys.stderr,
+                f"The parsed notebooks, are still present at:\n\t{temp_path}", file=sys.stderr,
             )
         else:
             NotebookParser.clean_up()

--- a/flake8_nb/flake8_integration/formatter.py
+++ b/flake8_nb/flake8_integration/formatter.py
@@ -6,7 +6,7 @@ original notebook and the cell the code in."""
 
 import optparse
 import os
-from typing import Tuple
+from typing import Tuple, Union
 
 from flake8.formatting.default import Default
 from flake8.style_guide import Violation
@@ -50,7 +50,7 @@ class IpynbFormatter(Default):
         if filename.lower().endswith(".ipynb_parsed"):
             map_result = self.map_notebook_error(error)
             if map_result:
-                filename, line_number = self.map_notebook_error(error)
+                filename, line_number = map_result
                 return self.error_format % {
                     "code": error.code,
                     "text": error.text,
@@ -63,7 +63,7 @@ class IpynbFormatter(Default):
         else:
             return super().format(error)
 
-    def map_notebook_error(self, error: Violation) -> Tuple[str, int]:
+    def map_notebook_error(self, error: Violation) -> Union[Tuple[str, int], None]:
         """
         Maps the error caused by an intermediate file back
         to a notebook, the input cell it caused and the

--- a/flake8_nb/flake8_integration/formatter.py
+++ b/flake8_nb/flake8_integration/formatter.py
@@ -14,6 +14,38 @@ from flake8.style_guide import Violation
 from ..parsers.notebook_parsers import NotebookParser, map_intermediate_to_input
 
 
+def map_notebook_error(violation: Violation) -> Union[Tuple[str, int], None]:
+    """
+    Maps the violation caused by an intermediate file back
+    to a notebook, the input cell it caused and the
+    respective line number in that cell.
+
+    Parameters
+    ----------
+    violation : Violation
+        Reported violation from checking the parsed notebook
+
+    Returns
+    -------
+    Tuple[str, int]
+        (filename, input_cell_line_number)
+        ``filename`` being the name of the original notebook and
+        the input cell were the violation was reported.
+        ``input_cell_line_number`` line number in the input cell
+        were the violation was reported.
+    """
+    intermediate_filename = os.path.abspath(violation.filename)
+    intermediate_line_number = violation.line_number
+    mappings = NotebookParser.get_mappings()
+    for original_notebook, intermediate_py, input_line_mapping in mappings:
+        if os.path.samefile(intermediate_py, intermediate_filename):
+            input_cell_name, input_cell_line_number = map_intermediate_to_input(
+                input_line_mapping, intermediate_line_number
+            )
+            filename = f"{original_notebook}#{input_cell_name}"
+            return filename, input_cell_line_number
+
+
 class IpynbFormatter(Default):
     r"""
     Default flake8_nb formatter for jupyter notebooks.
@@ -24,20 +56,20 @@ class IpynbFormatter(Default):
     def __init__(self, options: optparse.Values) -> None:
         super().__init__(options)
 
-    def after_init(self):  # type: () -> None
+    def after_init(self) -> None:
         """Check for a custom format string."""
         if self.options.format.lower() != "default_notebook":
             self.error_format = self.options.format
 
-    def format(self, error: Violation) -> str:
+    def format(self, violation: Violation) -> str:
         r"""
         Formats the error detected by a flake8 checker,
-        depending on if the error was caused by a ``*.py`` file
+        depending on if the violation was caused by a ``*.py`` file
         or by a parsed notebook.
 
         Parameters
         ----------
-        error : Violation
+        violation : Violation
             Error a checker reported.
 
         Returns
@@ -46,50 +78,19 @@ class IpynbFormatter(Default):
             Formatted error message, which will be displayed
             in the terminal.
         """
-        filename = error.filename
+        filename = violation.filename
         if filename.lower().endswith(".ipynb_parsed"):
-            map_result = self.map_notebook_error(error)
+            map_result = map_notebook_error(violation)
             if map_result:
                 filename, line_number = map_result
                 return self.error_format % {
-                    "code": error.code,
-                    "text": error.text,
+                    "code": violation.code,
+                    "text": violation.text,
                     "path": filename,
                     "row": line_number,
-                    "col": error.column_number,
+                    "col": violation.column_number,
                 }
 
-            return super().format(error)
+            return super().format(violation)
         else:
-            return super().format(error)
-
-    def map_notebook_error(self, error: Violation) -> Union[Tuple[str, int], None]:
-        """
-        Maps the error caused by an intermediate file back
-        to a notebook, the input cell it caused and the
-        respective line number in that cell.
-
-        Parameters
-        ----------
-        error : Violation
-            Reported error from checking the parsed notebook
-
-        Returns
-        -------
-        Tuple[str, int]
-            (filename, input_cell_line_number)
-            ``filename`` being the name of the original notebook and
-            the input cell were the error was reported.
-            ``input_cell_line_number`` line number in the input cell
-            were the error was reported.
-        """
-        intermediate_filename = os.path.abspath(error.filename)
-        intermediate_line_number = error.line_number
-        mappings = NotebookParser.get_mappings()
-        for original_notebook, intermediate_py, input_line_mapping in mappings:
-            if os.path.samefile(intermediate_py, intermediate_filename):
-                input_cell_name, input_cell_line_number = map_intermediate_to_input(
-                    input_line_mapping, intermediate_line_number
-                )
-                filename = f"{original_notebook}#{input_cell_name}"
-                return filename, input_cell_line_number
+            return super().format(violation)

--- a/flake8_nb/parsers/cell_parsers.py
+++ b/flake8_nb/parsers/cell_parsers.py
@@ -118,8 +118,7 @@ def extract_inline_flake8_noqa(source_line: str) -> List[str]:
             return [line.strip() for line in flake8_noqa_rules]
         elif match.group("has_flake8_noqa_all"):  # pragma: no branch
             return ["noqa"]
-    else:
-        return []
+    return []
 
 
 def flake8_tag_to_rules_dict(flake8_tag: str) -> Dict[str, List[str]]:
@@ -165,7 +164,7 @@ def flake8_tag_to_rules_dict(flake8_tag: str) -> Dict[str, List[str]]:
 
 def update_rules_dict(
     total_rules_dict: Dict[str, List], new_rules_dict: Dict[str, List]
-) -> Dict[str, List]:
+) -> None:
     """
     Updates the rules dict ``total_rules_dict`` with ``new_rules_dict``.
     If any entry of a key is 'noqa' (ignore all), the rules will be

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+from typing import Iterator
 
 import pytest
 
@@ -9,7 +10,7 @@ from .parsers.test_notebook_parsers import TEST_NOTEBOOK_BASE_PATH
 
 
 @pytest.fixture(scope="function")
-def notebook_parser() -> NotebookParser:
+def notebook_parser() -> Iterator[NotebookParser]:
     notebooks = [
         "not_a_notebook.ipynb",
         "notebook_with_flake8_tags.ipynb",

--- a/tests/flake8_integration/test_cli.py
+++ b/tests/flake8_integration/test_cli.py
@@ -30,7 +30,7 @@ def test_Flake8NbApplication__hack_flake8_program_and_version():
     assert app.program == program
     assert app.version == __version__
     assert app.option_manager.parser.prog == program
-    assert app.option_manager.parser.version == __version__
+    assert app.option_manager.parser.version == __version__  # type: ignore
     assert app.option_manager.program_name == program
     assert app.option_manager.version == __version__
 

--- a/tests/flake8_integration/test_formatter.py
+++ b/tests/flake8_integration/test_formatter.py
@@ -5,6 +5,9 @@ from typing import List
 
 import pytest
 
+from optparse import Values
+from flake8.style_guide import Violation
+
 from flake8_nb.flake8_integration.formatter import IpynbFormatter
 from flake8_nb.parsers.notebook_parsers import NotebookParser
 
@@ -22,19 +25,19 @@ def get_test_intermediate_path(intermediate_names):
     return filename
 
 
-class MockedOption:
-    def __init__(self, formatter="default_notebook"):
-        self.output_file = ""
-        self.format = formatter
+def get_mocked_option(formatter="default_notebook") -> Values:
+    return Values({"output_file": "", "format": formatter})
 
 
-class MockError:
-    def __init__(self, filename: str, line_number: int):
-        self.filename = os.path.normpath(filename)
-        self.line_number = line_number
-        self.code = "AB123"
-        self.text = "This is just for the coverage"
-        self.column_number = 2
+def get_mocked_violation(filename: str, line_number: int) -> Violation:
+    return Violation(
+        filename=os.path.normpath(filename),
+        line_number=line_number,
+        physical_line=0,
+        column_number=2,
+        code="AB123",
+        text="This is just for the coverage",
+    )
 
 
 @pytest.mark.parametrize(
@@ -47,12 +50,14 @@ def test_IpynbFormatter__map_notebook_error(
     expected_input_number: int,
     expected_line_number: int,
 ):
-    mocked_option = MockedOption()
+    mocked_option = get_mocked_option()
     formatter = IpynbFormatter(mocked_option)
     expected_filename = TEST_NOTEBOOK_PATH.format(expected_input_number)
     filename = get_test_intermediate_path(notebook_parser.intermediate_py_file_paths)
-    mock_error = MockError(filename, line_number)
-    filename, input_cell_line_number = formatter.map_notebook_error(mock_error)
+    mock_error = get_mocked_violation(filename, line_number)
+    map_result = formatter.map_notebook_error(mock_error)
+    assert map_result is not None
+    filename, input_cell_line_number = map_result
     assert input_cell_line_number == expected_line_number
     assert filename == expected_filename
 
@@ -93,7 +98,7 @@ def test_IpynbFormatter__format(
     format_str: str,
     expected_result_str: str,
 ):
-    mocked_option = MockedOption(format_str)
+    mocked_option = get_mocked_option(format_str)
     formatter = IpynbFormatter(mocked_option)
     if file_path_list:
         filename = expected_filename = os.path.join(*file_path_list)
@@ -102,7 +107,7 @@ def test_IpynbFormatter__format(
         filename = get_test_intermediate_path(
             notebook_parser.intermediate_py_file_paths
         )
-    mock_error = MockError(filename, 8)
+    mock_error = get_mocked_violation(filename, 8)
     result = formatter.format(mock_error)
     expected_result = expected_result_str.format(expected_filename=expected_filename)
     assert result == expected_result

--- a/tests/flake8_integration/test_formatter.py
+++ b/tests/flake8_integration/test_formatter.py
@@ -8,7 +8,7 @@ import pytest
 from optparse import Values
 from flake8.style_guide import Violation
 
-from flake8_nb.flake8_integration.formatter import IpynbFormatter
+from flake8_nb.flake8_integration.formatter import IpynbFormatter, map_notebook_error
 from flake8_nb.parsers.notebook_parsers import NotebookParser
 
 TEST_NOTEBOOK_PATH = os.path.join(
@@ -50,12 +50,10 @@ def test_IpynbFormatter__map_notebook_error(
     expected_input_number: int,
     expected_line_number: int,
 ):
-    mocked_option = get_mocked_option()
-    formatter = IpynbFormatter(mocked_option)
     expected_filename = TEST_NOTEBOOK_PATH.format(expected_input_number)
     filename = get_test_intermediate_path(notebook_parser.intermediate_py_file_paths)
     mock_error = get_mocked_violation(filename, line_number)
-    map_result = formatter.map_notebook_error(mock_error)
+    map_result = map_notebook_error(mock_error)
     assert map_result is not None
     filename, input_cell_line_number = map_result
     assert input_cell_line_number == expected_line_number
@@ -65,16 +63,8 @@ def test_IpynbFormatter__map_notebook_error(
 @pytest.mark.parametrize(
     "format_str,file_path_list,expected_result_str",
     [
-        (
-            "default_notebook",
-            [],
-            "{expected_filename}:2:2: AB123 This is just for the coverage",
-        ),
-        (
-            "%(path)s:%(row)d: %(text)s",
-            [],
-            "{expected_filename}:2: This is just for the coverage",
-        ),
+        ("default_notebook", [], "{expected_filename}:2:2: AB123 This is just for the coverage",),
+        ("%(path)s:%(row)d: %(text)s", [], "{expected_filename}:2: This is just for the coverage",),
         (
             "default_notebook",
             ["tests", "data", "notebooks", "falsy_python_file.py"],
@@ -82,12 +72,7 @@ def test_IpynbFormatter__map_notebook_error(
         ),
         (
             "default_notebook",
-            [
-                "tests",
-                "data",
-                "intermediate_py_files",
-                "notebook_with_flake8_tags.ipynb_parsed",
-            ],
+            ["tests", "data", "intermediate_py_files", "notebook_with_flake8_tags.ipynb_parsed"],
             "{expected_filename}:8:2: AB123 This is just for the coverage",
         ),
     ],
@@ -104,9 +89,7 @@ def test_IpynbFormatter__format(
         filename = expected_filename = os.path.join(*file_path_list)
     else:
         expected_filename = TEST_NOTEBOOK_PATH.format(1)
-        filename = get_test_intermediate_path(
-            notebook_parser.intermediate_py_file_paths
-        )
+        filename = get_test_intermediate_path(notebook_parser.intermediate_py_file_paths)
     mock_error = get_mocked_violation(filename, 8)
     result = formatter.format(mock_error)
     expected_result = expected_result_str.format(expected_filename=expected_filename)

--- a/tox.ini
+++ b/tox.ini
@@ -5,14 +5,14 @@ envlist = py{36,37,38}, flake8-nightly, flake8-legacy, flake8, docs, docs-links
 
 
 [flake8]
-max-line-length = 99
+max-line-length = 100
 exclude=
     *.ipynb_checkpoints/*
     *.tox*
     tests/data/notebooks
 
 [flake8_nb]
-max-line-length = 99
+max-line-length = 100
 ; exclude=
 ;     *.ipynb_checkpoints/*
 ;     *.tox*

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 minversion = 3.4.0
+skip_missing_interpreters=true
 envlist = py{36,37,38}, flake8-nightly, flake8-legacy, flake8, docs, docs-links
 
 


### PR DESCRIPTION
This refactor solves most typing inconsistencies.
Some are ignored since they arise from version compat (`flake8` uses `argparse` instead of `optparse` after version `3.7.9`).
Since `flake8==3.7.9` is [still used actively](https://pepy.tech/project/flake8?versions=3.7.9&versions=3.8.3), the support will be kept for now.