### PR TITLE
Add flake8 version help

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,9 +3,9 @@ version: 2
 formats: all
 
 build:
-    image: latest
+  image: latest
 
 python:
-    version: 3.7
-    install:
-        - requirements: requirements_dev.txt
+  version: 3.7
+  install:
+    - requirements: requirements_dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ commands_pre =
   {[testenv]commands_pre}
   {envpython} -m pip install -U -q 'flake8==3.7.0'
 commands =
-  {[testenv:flake8-nightly]commands}
+  py.test -vv --cov=flake8_nb --cov-append --cov-config .coveragerc tests
 
 [testenv]
 passenv = *


### PR DESCRIPTION
This adds the flake8 version when calling with the flags `--help` or `--version`

### Before:

```bash
$ flake8-nb --version
0.2.0 (mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0, pylint: 2.5.2)
CPython 3.7.4 on Windows
```
```bash
$ flake8-nb --help
.
.
.
Installed plugins: mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0, pylint: 2.5.2
```
### After:

```bash
$ flake8-nb --version
0.2.0 (flake8: 3.8.1, mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0, pylint: 2.5.2)
CPython 3.7.4 on Windows
```
```bash
$ flake8-nb --help
.
.
.
Installed plugins: flake8: 3.8.1, mccabe: 0.6.1, pycodestyle: 2.6.0, pyflakes: 2.2.0, pylint: 2.5.2
```
