### PR TITLE
Force utf8 encoding when reading file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 0.2.1 (2020-08-11)
+
+- Forced uft8 encoding when reading notebooks,
+  this prevents errors on windows when console codepage is assumed
+
 ## 0.2.0 (2020-07-18)
 
 - Added pre-commit hook ([#47](https://github.com/s-weigand/flake8-nb/pull/47))

--- a/flake8_nb/parsers/notebook_parsers.py
+++ b/flake8_nb/parsers/notebook_parsers.py
@@ -69,7 +69,7 @@ def read_notebook_to_cells(notebook_path: str) -> List[Dict]:
         If the notebook couldn't be parsed.
     """
     try:
-        with open(notebook_path) as notebook_file:
+        with open(notebook_path, encoding="utf8") as notebook_file:
             notebook_cells = json.load(notebook_file)["cells"]
             return notebook_cells
     except (json.JSONDecodeError, KeyError):
@@ -265,7 +265,7 @@ def create_intermediate_py_file(
 
     intermediate_code += "".join(intermediate_py_str_list).rstrip("\n")
     if intermediate_code:
-        with open(intermediate_file_path, "w+") as intermediate_file:
+        with open(intermediate_file_path, "w+", encoding="utf8") as intermediate_file:
             intermediate_file.write(f"{intermediate_code}\n")
         return intermediate_file_path, input_line_mapping
     else:


### PR DESCRIPTION
Forcing utf8 encoding when reading files, will prevent errors on windows when console codepage is assumed.