### PR TITLE
📚 Change RTD dependency installation order

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,8 +6,8 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.8
   install:
-    - requirements: requirements_dev.txt
     - method: pip
       path: .
+    - requirements: requirements_dev.txt


### PR DESCRIPTION
This should install 'jinja2~=2.11', instead of upgrading to 3.0, which breaks nbsphinx see issue 563