### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,12 +28,12 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.0
+    rev: v2.19.1
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/python/black
-    rev: 21.5b1
+    rev: 21.5b2
     hooks:
       - id: black
         language_version: python3
@@ -60,7 +60,7 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.0 # Use the sha or tag you want to point at
+    rev: v2.3.1 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://gitlab.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: validate_manifest
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.902
     hooks:
       - id: mypy
         exclude: "^(docs|tests|.github)"
@@ -28,12 +28,12 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.1
+    rev: v2.19.4
     hooks:
       - id: pyupgrade
         args: [--py36-plus]
   - repo: https://github.com/python/black
-    rev: 21.5b2
+    rev: 21.6b0
     hooks:
       - id: black
         language_version: python3
@@ -96,12 +96,12 @@ repos:
         additional_dependencies: [sphinx, rstcheck]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: rst-backticks
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         files: ".py|.rst|.md"


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/flake8-nb/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.13.0-py2.py3-none-any.whl (190 kB)
Collecting identify>=1.0.0
  Downloading identify-2.2.10-py2.py3-none-any.whl (98 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl (630 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.0-py2.py3-none-any.whl (7.3 kB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.4.7-py2.py3-none-any.whl (7.2 MB)
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting appdirs<2,>=1.4.3
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting filelock<4,>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.2-py2.py3-none-any.whl (338 kB)
Installing collected packages: six, filelock, distlib, appdirs, virtualenv, toml, pyyaml, nodeenv, identify, cfgv, pre-commit
Successfully installed appdirs-1.4.4 cfgv-3.3.0 distlib-0.3.2 filelock-3.0.12 identify-2.2.10 nodeenv-1.6.0 pre-commit-2.13.0 pyyaml-5.4.1 six-1.16.0 toml-0.10.2 virtualenv-20.4.7
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/pre-commit/pre-commit ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
updating v0.812 -> v0.902.
Updating https://github.com/MarcoGorelli/absolufy-imports ... [INFO] Initializing environment for https://github.com/MarcoGorelli/absolufy-imports.
already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.19.1 -> v2.19.4.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
updating 21.5b2 -> 21.6b0.
Updating https://github.com/kynan/nbstripout ... [INFO] Initializing environment for https://github.com/kynan/nbstripout.
already up to date.
Updating https://github.com/kynan/nbstripout ... already up to date.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://gitlab.com/pycqa/flake8 ... [INFO] Initializing environment for https://gitlab.com/pycqa/flake8.
already up to date.
Updating https://github.com/PyCQA/isort ... [INFO] Initializing environment for https://github.com/PyCQA/isort.
already up to date.
Updating https://github.com/PyCQA/pydocstyle ... [INFO] Initializing environment for https://github.com/PyCQA/pydocstyle.
already up to date.
Updating https://github.com/terrencepreilly/darglint ... [INFO] Initializing environment for https://github.com/terrencepreilly/darglint.
already up to date.
Updating https://github.com/econchick/interrogate ... [INFO] Initializing environment for https://github.com/econchick/interrogate.
already up to date.
Updating https://github.com/myint/rstcheck ... 
=====> /home/runner/.cache/pre-commit/repol15zeyh7/.pre-commit-hooks.yaml is not a file
Updating https://github.com/pre-commit/pygrep-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
updating v1.8.0 -> v1.9.0.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
updating v2.0.0 -> v2.1.0.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@2.3.1.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/absolufy-imports.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/kynan/nbstripout.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://gitlab.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Check python ast.........................................................Passed
Check builtin type constructor use.......................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
Debug Statements (Python)................................................Passed
Fix python encoding pragma...............................................Passed
Validate Pre-Commit Manifest.............................................Passed
mypy.....................................................................Passed
absolufy-imports.........................................................Passed
pyupgrade................................................................Passed
black....................................................................Passed
nbstripout no notebook_with_out_flake8_tags..............................Passed
nbstripout only notebook_with_out_flake8_tags............................Passed
setup-cfg-fmt............................................................Passed
prettier.................................................................Passed
flake8...................................................................Passed
isort....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)