### PR TITLE
🧹 Remove broken Dependabot badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![Documentation Status](https://readthedocs.org/projects/flake8-nb/badge/?version=latest)](https://flake8-nb.readthedocs.io/en/latest/?badge=latest)
 [![Testing Coverage](https://codecov.io/gh/s-weigand/flake8-nb/branch/main/graph/badge.svg)](https://codecov.io/gh/s-weigand/flake8-nb)
 [![Documentation Coverage](https://flake8-nb.readthedocs.io/en/latest/_static/interrogate_badge.svg)](https://github.com/s-weigand/flake8-nb)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=s-weigand/flake8-nb)](https://dependabot.com)
 
 [![Code quality](https://api.codacy.com/project/badge/Grade/d02b436a637243a1b626b74d018c3bbe)](https://www.codacy.com/manual/s.weigand.phy/flake8-nb?utm_source=github.com&utm_medium=referral&utm_content=s-weigand/flake8-nb&utm_campaign=Badge_Grade)
 [![All Contributors](https://img.shields.io/github/all-contributors/s-weigand/flake8-nb)](#contributors)


### PR DESCRIPTION
Since the dependabot badge doesn't work properly for 1.5y (https://github.com/dependabot/dependabot-core/issues/1912) and for 1 months is broken (404 response) and breaks the link checking CI test, it should be removed.