### PR TITLE
🚇🩹 Fix CI dependency installation

### DIFF
--- a/.github/workflows/test-nightly-schedule.yml
+++ b/.github/workflows/test-nightly-schedule.yml
@@ -20,7 +20,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U -r requirements_dev.txt
           python -m pip install .
-          python -m pip install --force-reinstall -U -q git+https://gitlab.com/pycqa/flake8.git
+          python -m pip install --force-reinstall -U -q git+https://github.com/pycqa/flake8
       - name: Show flake8 version
         run: |
           pip freeze | grep flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,8 +167,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U -r requirements_dev.txt
           pip install .
+          python -m pip install -U -r requirements_dev.txt
       - name: Run tests
         run: |
           python -m pytest --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
           python -m pip install -U pip
           python -m pip install -U -r requirements_dev.txt
           pip install .
-          python -m pip install --force-reinstall -U -q git+https://gitlab.com/pycqa/flake8.git
+          python -m pip install --force-reinstall -U -q git+https://github.com/pycqa/flake8
       - name: Show flake8 version
         run: |
           pip freeze | grep flake8


### PR DESCRIPTION
- [⬆️🩹 Updated nightly flake8 url to point at github instead of gitlab mirror](https://github.com/s-weigand/flake8-nb/commit/7f7db4e56a45569989b6f9a073a88ccbb3dea6f3)
- [🩹🚇 Change installation order so pinned versions do not get uninstalled](https://github.com/s-weigand/flake8-nb/commit/15024403e0547b971065a57945d3cbfeaae4dfd9)