### PR TITLE
✨Add support for flake8>=5.0.0

### DIFF
--- a/.github/workflows/test-pre-coomit-hook.yml
+++ b/.github/workflows/test-pre-coomit-hook.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-hook-test
+          key: pre-commit-hook-test-${{ hashFiles('requirements_dev.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install -U pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
           python -m pip install -U pip
           pip install .
           python -m pip install -U -r requirements_dev.txt
-          python -m pip install -U -q 'flake8==3.7.0'
+          python -m pip install -U -q 'flake8==3.8.0'
       - name: Show flake8 version
         run: |
           pip freeze | grep flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -56,16 +56,17 @@ repos:
         files: "notebook_with_out_flake8_tags"
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.2
+    rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
+        args: [--include-version-classifiers]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
@@ -91,7 +92,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/rstcheck/rstcheck
-    rev: "v6.0.0.post1"
+    rev: "v6.1.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]
@@ -109,7 +110,7 @@ repos:
         files: ".py|.rst|.md"
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,7 +12,7 @@ This packages skeleton was created with Cookiecutter_ and the
 The idea to use cell tags was inspired by the use of cell tags in nbval_.
 
 
-.. _flake8: https://gitlab.com/pycqa/flake8
+.. _flake8: https://github.com/pycqa/flake8
 .. _Cookiecutter: https://github.com/cookiecutter/cookiecutter
 .. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage
 .. _nbval: https://github.com/computationalmodelling/nbval

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![Code style Python: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Binder](https://static.mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/s-weigand/flake8-nb.git/main?urlpath=lab%2Ftree%2Ftests%2Fdata%2Fnotebooks)
 
-[`flake8`](https://gitlab.com/pycqa/flake8) checking for jupyter notebooks.
+[`flake8`](https://github.com/pycqa/flake8) checking for jupyter notebooks.
 Basically this is a hack on the `flake8`'s `Application` class,
 which adds parsing and a cell based formatter for `*.ipynb` files.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.0 (2022-08-15)
+
+- Drop support for `flake8` to be `<3.8.0` [#240](https://github.com/s-weigand/flake8-nb/pull/240)
+- Set max supported version of `flake8` to be `<5.0.5` [#240](https://github.com/s-weigand/flake8-nb/pull/240)
+- Enable calling `flake8_nb` as python module [#240](https://github.com/s-weigand/flake8-nb/pull/240)
+
 ## 0.4.0 (2022-02-21)
 
 - Drop official python 3.6 support

--- a/flake8_nb/__init__.py
+++ b/flake8_nb/__init__.py
@@ -8,9 +8,7 @@ import flake8
 
 from flake8_nb.flake8_integration.formatter import IpynbFormatter
 
-__all__ = [
-    IpynbFormatter.__name__,
-]
+__all__ = ["IpynbFormatter"]
 
 
 def save_cast_int(int_str: str) -> int:

--- a/flake8_nb/__main__.py
+++ b/flake8_nb/__main__.py
@@ -21,3 +21,7 @@ def main(argv: list[str] | None = None) -> None:
     app = Flake8NbApplication()
     app.run(sys.argv[1:] if argv is None else argv[1:])
     app.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/flake8_nb/__main__.py
+++ b/flake8_nb/__main__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import sys
 
-from flake8_nb import FLAKE8_VERSION_TUPLE
 from flake8_nb.flake8_integration.cli import Flake8NbApplication
 
 
@@ -19,8 +18,6 @@ def main(argv: list[str] | None = None) -> None:
     argv: list[str] | None
         The arguments to be passed to the application for parsing.
     """
-    if FLAKE8_VERSION_TUPLE > (3, 7, 9):
-        argv = sys.argv[1:] if argv is None else argv[1:]
     app = Flake8NbApplication()
-    app.run(argv)
+    app.run(sys.argv[1:] if argv is None else argv[1:])
     app.exit()

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -152,8 +152,8 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         version : str
             Application version, by default __version__
         """
-        super().__init__(program, version)
-        self.hack_flake8_program_and_version(program, version)
+        super().__init__()
+        self.hack_flake8_program_and_version("flake8_nb", __version__)
         self.hack_options()
         self.set_flake8_option(
             "--keep-parsed-notebooks",

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -380,10 +380,14 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
 
         if self.options.bug_report:
             info = debug.information(__version__, self.plugins)
+            for index, plugin in enumerate(info["plugins"]):
+                if plugin["plugin"] == "flake8-nb":
+                    del info["plugins"][index]
+            info["flake8-version"] = flake_version
             print(json.dumps(info, indent=2, sort_keys=True))
             raise SystemExit(0)
 
-        if self.options.diff:
+        if self.options.diff:  # pragma: no cover
             LOG.warning(
                 "the --diff option is deprecated and will be removed in a " "future version."
             )

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -7,6 +7,7 @@ of the CLI argv and config of ``flake8``.
 """
 from __future__ import annotations
 
+import configparser
 import logging
 import os
 import sys
@@ -153,6 +154,19 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
             Application version, by default __version__
         """
         super().__init__()
+        if FLAKE8_VERSION_TUPLE < (5, 0, 0):
+            self.apply_hacks()
+            self.option_manager.generate_versions = hack_option_manager_generate_versions(
+                self.option_manager.generate_versions
+            )
+            self.parse_configuration_and_cli = (  # type: ignore[assignment]
+                self.parse_configuration_and_cli_legacy  # type: ignore[assignment]
+            )
+        else:
+            self.register_plugin_options = self.hacked_register_plugin_options
+
+    def apply_hacks(self) -> None:
+        """Apply hacks to flake8 adding options and changing the application name + version."""
         self.hack_flake8_program_and_version("flake8_nb", __version__)
         self.hack_options()
         self.set_flake8_option(
@@ -171,13 +185,24 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
             "Possible variables which will be replaces 'nb_path', 'exec_count',"
             "'code_cell_count' and 'total_cell_count'. (Default: %default)",
         )
-        self.option_manager.generate_versions = hack_option_manager_generate_versions(
-            self.option_manager.generate_versions
+
+    def hacked_register_plugin_options(self) -> None:
+        """Register options provided by plugins to our option manager."""
+        assert self.plugins is not None
+        from flake8.main import options
+        from flake8.options import manager
+
+        plugin_version = ", ".join(
+            [v for v in self.plugins.versions_str().split(", ") if not v.startswith("flake8-nb")]
         )
-        if FLAKE8_VERSION_TUPLE < (3, 8, 0):
-            self.parse_configuration_and_cli = (  # type: ignore[assignment]
-                self.parse_configuration_and_cli_legacy  # type: ignore[assignment]
-            )
+
+        self.option_manager = manager.OptionManager(
+            version=__version__,
+            plugin_versions=f"flake8: {flake_version}, {plugin_version}",
+            parents=[self.prelim_arg_parser],
+        )
+        options.register_default_options(self.option_manager)
+        self.option_manager.register_plugins(self.plugins)
 
     def hack_flake8_program_and_version(self, program: str, version: str) -> None:
         """Hack to overwrite the program name and version of flake8.
@@ -223,15 +248,12 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         if is_option:
             # pylint: disable=no-member
             parser = self.option_manager.parser
-            if FLAKE8_VERSION_TUPLE > (3, 7, 9):
-                for index, action in enumerate(parser._actions):  # pragma: no branch
-                    if long_option_name in action.option_strings:
-                        parser._handle_conflict_resolve(
-                            None, [(long_option_name, parser._actions[index])]
-                        )
-                        break
-            else:
-                parser.remove_option(long_option_name)
+            for index, action in enumerate(parser._actions):  # pragma: no branch
+                if long_option_name in action.option_strings:
+                    parser._handle_conflict_resolve(
+                        None, [(long_option_name, parser._actions[index])]
+                    )
+                    break
         self.option_manager.add_option(long_option_name, *args, **kwargs)
 
     def hack_options(self) -> None:
@@ -278,40 +300,6 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         return args + notebook_parser.intermediate_py_file_paths
 
     def parse_configuration_and_cli_legacy(
-        self,
-        argv: list[str] | None = None,
-    ) -> None:
-        """Compat version of self.parse_configuration_and_cli to work with flake8 >=3.7.0,<= 3.7.9 .
-
-        See https://gitlab.com/pycqa/flake8/blob/master/src/flake8/main/application.py#L194
-
-        Parse configuration files and the CLI options.
-
-        Parameters
-        ----------
-        argv: list[str] | None
-            Command-line arguments passed in directly.
-        """
-        if self.options is None and self.args is None:  # type: ignore  # pragma: no branch
-            # pylint: disable=no-member
-            self.options, self.args = aggregator.aggregate_options(
-                self.option_manager, self.config_finder, argv
-            )
-
-        self.args = self.hack_args(self.args, self.options.exclude)
-
-        self.running_against_diff = self.options.diff
-        if self.running_against_diff:  # pragma: no cover
-            self.parsed_diff = utils.parse_unified_diff()
-            if not self.parsed_diff:
-                self.exit()
-
-        self.options._running_from_vcs = False
-
-        self.check_plugins.provide_options(self.option_manager, self.options, self.args)
-        self.formatting_plugins.provide_options(self.option_manager, self.options, self.args)
-
-    def parse_configuration_and_cli(
         self, config_finder: config.ConfigFileFinder, argv: list[str]
     ) -> None:
         """Parse configuration files and the CLI options.
@@ -342,11 +330,90 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         self.check_plugins.provide_options(self.option_manager, self.options, self.args)
         self.formatting_plugins.provide_options(self.option_manager, self.options, self.args)
 
+    def parse_configuration_and_cli(
+        self,
+        cfg: configparser.RawConfigParser,
+        cfg_dir: str,
+        argv: list[str],
+    ) -> None:
+        """
+        Parse configuration files and the CLI options.
+
+        Parameters
+        ----------
+        cfg: configparser.RawConfigParser
+            Config parser instance
+        cfg_dir: str
+            Dir the the config is in.
+        argv: list[str]
+            CLI args
+
+        Raises
+        ------
+        SystemExit
+            If ``--bug-report`` option is passed to the CLI.
+        """
+        assert self.option_manager is not None
+        assert self.plugins is not None
+
+        self.apply_hacks()
+
+        self.options = aggregator.aggregate_options(
+            self.option_manager,
+            cfg,
+            cfg_dir,
+            argv,
+        )
+
+        argv = self.hack_args(argv, self.options.exclude)
+
+        self.options = aggregator.aggregate_options(
+            self.option_manager,
+            cfg,
+            cfg_dir,
+            argv,
+        )
+
+        import json
+
+        from flake8.main import debug
+
+        if self.options.bug_report:
+            info = debug.information(__version__, self.plugins)
+            print(json.dumps(info, indent=2, sort_keys=True))
+            raise SystemExit(0)
+
+        if self.options.diff:
+            LOG.warning(
+                "the --diff option is deprecated and will be removed in a " "future version."
+            )
+            self.parsed_diff = utils.parse_unified_diff()
+
+        for loaded in self.plugins.all_plugins():
+            parse_options = getattr(loaded.obj, "parse_options", None)
+            if parse_options is None:
+                continue
+
+            # XXX: ideally we wouldn't have two forms of parse_options
+            try:
+                parse_options(
+                    self.option_manager,
+                    self.options,
+                    self.options.filenames,
+                )
+            except TypeError:
+                parse_options(self.options)
+
     def exit(self) -> None:
         """Handle finalization and exiting the program.
 
         This should be the last thing called on the application instance. It
         will check certain options and exit appropriately.
+
+        Raises
+        ------
+        SystemExit
+            For flake8>=5.0.0
         """
         if self.options.keep_parsed_notebooks:
             temp_path = NotebookParser.temp_path
@@ -356,4 +423,7 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
             )
         else:
             NotebookParser.clean_up()
-        super().exit()
+        if FLAKE8_VERSION_TUPLE < (5, 0, 0):
+            super().exit()
+        else:
+            raise SystemExit(self.exit_code())

--- a/flake8_nb/flake8_integration/formatter.py
+++ b/flake8_nb/flake8_integration/formatter.py
@@ -9,13 +9,17 @@ from __future__ import annotations
 import os
 from typing import cast
 
-from flake8.formatting.default import COLORS
-from flake8.formatting.default import COLORS_OFF
 from flake8.formatting.default import Default
 from flake8.style_guide import Violation
 
 from flake8_nb.parsers.notebook_parsers import NotebookParser
 from flake8_nb.parsers.notebook_parsers import map_intermediate_to_input
+
+try:
+    from flake8.formatting.default import COLORS
+    from flake8.formatting.default import COLORS_OFF
+except ImportError:
+    COLORS = COLORS_OFF = {}
 
 
 def map_notebook_error(violation: Violation, format_str: str) -> tuple[str, int] | None:
@@ -71,6 +75,8 @@ class IpynbFormatter(Default):  # type: ignore[misc]
         """Check for a custom format string."""
         if self.options.format.lower() != "default_notebook":
             self.error_format = self.options.format
+        if not hasattr(self, "color"):
+            self.color = True
 
     def format(self, violation: Violation) -> str | None:
         r"""Format the error detected by a flake8 checker.

--- a/flake8_nb/flake8_integration/formatter.py
+++ b/flake8_nb/flake8_integration/formatter.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import os
 from typing import cast
 
+from flake8.formatting.default import COLORS
+from flake8.formatting.default import COLORS_OFF
 from flake8.formatting.default import Default
 from flake8.style_guide import Violation
 
@@ -101,6 +103,7 @@ class IpynbFormatter(Default):  # type: ignore[misc]
                         "path": filename,
                         "row": line_number,
                         "col": violation.column_number,
+                        **(COLORS if self.color else COLORS_OFF),
                     },
                 )
         return cast(str, super().format(violation))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,6 +14,6 @@ coverage[toml]>=4.5.4
 # doc requirements
 -r docs/requirements.txt
 # package runtime requirements
-flake8==4.0.1
+flake8==5.0.4
 nbconvert==6.5.0; python_version > '3.7'
 ipython==8.4.0; python_version > '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    flake8>=3.7.0,<4.0.2
+    flake8>=3.8.0,<5.0.5
     ipython>=7.8.0
     nbconvert>=5.6.0
 python_requires = >=3.7

--- a/tests/flake8_integration/test_formatter.py
+++ b/tests/flake8_integration/test_formatter.py
@@ -22,7 +22,12 @@ def get_test_intermediate_path(intermediate_names):
 
 def get_mocked_option(notebook_cell_format: str, formatter="default_notebook") -> Values:
     return Values(
-        {"output_file": "", "format": formatter, "notebook_cell_format": notebook_cell_format}
+        {
+            "output_file": "",
+            "format": formatter,
+            "notebook_cell_format": notebook_cell_format,
+            "color": "off",
+        }
     )
 
 

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -22,14 +22,14 @@ from tests import TEST_NOTEBOOK_BASE_PATH
 def test_run_main(
     capsys, keep_intermediate: bool, notebook_cell_format: str, expected_result: str
 ):
-    argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
+    argv = ["flake8_nb"]
     if keep_intermediate:
         argv.append("--keep-parsed-notebooks")
     argv += ["--notebook-cell-format", notebook_cell_format]
     argv += ["--exclude", "*.tox/*,*.ipynb_checkpoints*,*/docs/*"]
     with pytest.raises(SystemExit):
         with pytest.warns(InvalidNotebookWarning):
-            main(argv)
+            main([*argv, TEST_NOTEBOOK_BASE_PATH])
     captured = capsys.readouterr()
     result_output = captured.out
     result_list = result_output.replace("\r", "").split("\n")
@@ -49,14 +49,14 @@ def test_run_main(
 
 
 def test_run_main_all_excluded(capsys):
-    argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
+    argv = ["flake8_nb"]
     argv += [
         "--exclude",
         f"*.tox/*,*.ipynb_checkpoints*,*/docs/*,{TEST_NOTEBOOK_BASE_PATH}",
     ]
     with pytest.raises(SystemExit):
         with pytest.warns(InvalidNotebookWarning):
-            main(argv)
+            main([*argv, TEST_NOTEBOOK_BASE_PATH])
     captured = capsys.readouterr()
     result_output = captured.out
     result_list = result_output.replace("\r", "").split("\n")
@@ -77,12 +77,14 @@ def test_run_main_all_excluded(capsys):
 def test_syscall(
     cli_entrypoint: str, keep_intermediate: bool, notebook_cell_format: str, expected_result: str
 ):
-    argv = [cli_entrypoint, TEST_NOTEBOOK_BASE_PATH]
+    argv = [cli_entrypoint]
     if keep_intermediate:
         argv.append("--keep-parsed-notebooks")
     argv += ["--notebook-cell-format", notebook_cell_format]
     argv += ["--exclude", "*.tox/*,*.ipynb_checkpoints*,*/docs/*"]
-    proc = subprocess.Popen(argv, stdout=subprocess.PIPE, universal_newlines=True)
+    proc = subprocess.Popen(
+        [*argv, TEST_NOTEBOOK_BASE_PATH], stdout=subprocess.PIPE, universal_newlines=True
+    )
     result_list = [str(line) for line in proc.stdout]
     expected_result_path = os.path.join(
         os.path.dirname(__file__), "data", f"{expected_result}.txt"

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -3,7 +3,6 @@ import subprocess
 
 import pytest
 
-from flake8_nb import FLAKE8_VERSION_TUPLE
 from flake8_nb.__main__ import main
 from flake8_nb.parsers.notebook_parsers import InvalidNotebookWarning
 from flake8_nb.parsers.notebook_parsers import NotebookParser
@@ -23,8 +22,6 @@ def test_run_main(
     capsys, keep_intermediate: bool, notebook_cell_format: str, expected_result: str
 ):
     argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
-    if FLAKE8_VERSION_TUPLE < (3, 8, 0):
-        argv = argv[1:]
     if keep_intermediate:
         argv.append("--keep-parsed-notebooks")
     argv += ["--notebook-cell-format", notebook_cell_format]
@@ -52,8 +49,6 @@ def test_run_main(
 
 def test_run_main_all_excluded(capsys):
     argv = ["flake8_nb", TEST_NOTEBOOK_BASE_PATH]
-    if FLAKE8_VERSION_TUPLE < (3, 8, 0):
-        argv = argv[1:]
     argv += [
         "--exclude",
         f"*.tox/*,*.ipynb_checkpoints*,*/docs/*,{TEST_NOTEBOOK_BASE_PATH}",

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -96,3 +97,12 @@ def test_syscall(
 
     for expected_result in expected_result_list:
         assert any(result.endswith(expected_result) for result in result_list)
+
+
+def test_flake8_nb_module_call():
+    """Call flake8_nb as python module ``python -m flake8_nb --help``."""
+    output = subprocess.run(
+        [sys.executable, "-m", "flake8_nb", "--help"], capture_output=True, check=True
+    )
+    assert output.returncode == 0
+    assert output.stdout.decode().startswith("usage: flake8_nb [options] file file ...")

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,9 +1,13 @@
+import json
 import os
 import subprocess
 import sys
 
 import pytest
+from flake8 import __version__ as flake_version
 
+from flake8_nb import FLAKE8_VERSION_TUPLE
+from flake8_nb import __version__
 from flake8_nb.__main__ import main
 from flake8_nb.parsers.notebook_parsers import InvalidNotebookWarning
 from flake8_nb.parsers.notebook_parsers import NotebookParser
@@ -108,3 +112,19 @@ def test_flake8_nb_module_call():
     )
     assert output.returncode == 0
     assert output.stdout.decode().startswith("usage: flake8_nb [options] file file ...")
+
+
+@pytest.mark.skipif(FLAKE8_VERSION_TUPLE < (5, 0, 0), reason="Only implemented for flake8>=5.0.0")
+def test_flake8_nb_bug_report():
+    """Debug information."""
+    output = subprocess.run(
+        [sys.executable, "-m", "flake8_nb", "--bug-report"], capture_output=True, check=True
+    )
+    assert output.returncode == 0
+    info = json.loads(output.stdout.decode())
+
+    assert "flake8-version" in info
+    assert info["flake8-version"] == flake_version
+    assert info["version"] == __version__
+
+    assert not any(plugin["plugin"] == "flake8-nb" for plugin in info["plugins"])

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands =
 passenv = *
 commands_pre =
   {[testenv]commands_pre}
-  {envpython} -m pip install -U -q 'flake8==3.7.0'
+  {envpython} -m pip install -U -q 'flake8==3.8.0'
 commands =
   py.test -vv
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands=pre-commit run --all
 passenv = *
 commands_pre =
   {[testenv]commands_pre}
-  {envpython} -m pip install -U -q --force-reinstall git+https://gitlab.com/pycqa/flake8.git
+  {envpython} -m pip install -U -q --force-reinstall git+https://github.com/pycqa/flake8
 commands =
   {envpython}  -c "import flake8_nb;print('FLAKE8 VERSION: ', flake8_nb.FLAKE8_VERSION_TUPLE)"
   py.test -vv


### PR DESCRIPTION
This PR adds support for `flake8>=5.0.0` and drops support for `flake8<3.8.0`.

In addition, it allows for `flake8_nb` to be called as python module `python -m flake8_nb`