### PR TITLE
🩹 Fix config discovery with flake8>=5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ venv.bak/
 # local hook testing files
 flake8-nb_run_output.txt
 hook_run_output.txt
+flake8_nb/flake8_integration/hacked_config.py

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -11,6 +11,7 @@ import configparser
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any
 from typing import Callable
 
@@ -134,6 +135,25 @@ def hack_option_manager_generate_versions(
         return f"{additional_output}, {original_output}"
 
     return hacked_generate_versions
+
+
+def hack_config_module() -> None:
+    """Create hacked version of ``flake8.options.config`` at runtime.
+
+    Since flake8>=5.0.0 uses hardcoded ``"flake8"`` to discover the config we replace
+    with it with ``"flake8_nb"`` to create our own hacked version and replace
+    the references to the original module with the hacked one.
+
+    See: https://github.com/s-weigand/flake8-nb/issues/249
+    """
+    hacked_config_source = Path(config.__file__).read_text().replace('"flake8"', '"flake8_nb"')
+    hacked_config_path = Path(__file__).parent / "hacked_config.py"
+    hacked_config_path.write_text(hacked_config_source)
+
+    from flake8_nb.flake8_integration import hacked_config
+
+    sys.modules["flake8.options.config"] = hacked_config
+    aggregator.config = hacked_config
 
 
 class Flake8NbApplication(Application):  # type: ignore[misc]
@@ -357,6 +377,7 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         assert self.plugins is not None
 
         self.apply_hacks()
+        hack_config_module()
 
         self.options = aggregator.aggregate_options(
             self.option_manager,

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -150,7 +150,7 @@ def hack_config_module() -> None:
     hacked_config_path = Path(__file__).parent / "hacked_config.py"
     hacked_config_path.write_text(hacked_config_source)
 
-    from flake8_nb.flake8_integration import hacked_config
+    from flake8_nb.flake8_integration import hacked_config  # type:ignore[attr-defined]
 
     sys.modules["flake8.options.config"] = hacked_config
     aggregator.config = hacked_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ known_first_party = ["flake8_nb", "tests"]
 force_single_line = true
 
 [tool.interrogate]
-exclude = ["setup.py", "docs", "tests", ".eggs"]
+exclude = ["setup.py", "docs", "tests", ".eggs","flake8_nb/flake8_integration/hacked_config.py"]
 ignore-init-module = true
 fail-under=100
 verbose = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,3 +85,4 @@ strict = True
 ignore_missing_imports = True
 scripts_are_modules = True
 show_error_codes = True
+warn_unused_ignores = False

--- a/tests/data/expected_output_config_test.txt
+++ b/tests/data/expected_output_config_test.txt
@@ -1,0 +1,2 @@
+cell_with_source_string.ipynb#In[1]:3:1: E302 expected 2 blank lines, found 1
+notebook_with_out_ipython_magic.ipynb#In[1]:1:4: E222 multiple spaces after operator


### PR DESCRIPTION
Since `flake8>=5.0.0` uses the [hardcoded config section identifier `"flake8"`](https://github.com/PyCQA/flake8/blob/e249dc47dfd314c34bbd0946c3fad970a8b15d6c/src/flake8/options/config.py) using the flake8_nb config (`[flake8_nb]`) is broken.
This fixes the issue by creating a hacked version of `flake8.options.config` at runtime, where `"flake8"` is replaced with `"flake8_nb"` and the original flake8 module is swapped with the hacked version.

closes #249 