### PR TITLE
🩹 Fix config file discovery

### DIFF
--- a/.github/workflows/test-nightly-schedule.yml
+++ b/.github/workflows/test-nightly-schedule.yml
@@ -26,4 +26,4 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
+          python -m pytest -vv

--- a/.github/workflows/test-nightly-schedule.yml
+++ b/.github/workflows/test-nightly-schedule.yml
@@ -26,4 +26,4 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
+          python -m pytest -vv
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:
@@ -143,7 +143,7 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
+          python -m pytest -vv
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:
@@ -171,7 +171,7 @@ jobs:
           python -m pip install -U -r requirements_dev.txt
       - name: Run tests
         run: |
-          python -m pytest --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
+          python -m pytest
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:
@@ -143,7 +143,7 @@ jobs:
           pip freeze | grep flake8
       - name: Run tests
         run: |
-          python -m pytest -vv --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+          python -m pytest -vv --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:
@@ -171,7 +171,7 @@ jobs:
           python -m pip install -U -r requirements_dev.txt
       - name: Run tests
         run: |
-          python -m pytest --cov=./ --cov-report term --cov-report xml --cov-config .coveragerc tests
+          python -m pytest --cov=flake8_nb --cov-report term --cov-report xml --cov-config pyproject.toml tests
       - name: Codecov Upload
         uses: codecov/codecov-action@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,12 +114,3 @@ repos:
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]
-  - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
-    hooks:
-      - id: interrogate
-        name: Update interrogate badge
-        args: [-vv, --config=pyproject.toml, -g, docs/_static]
-        pass_filenames: false
-        always_run: true
-        stages: [push]

--- a/flake8_nb/flake8_integration/cli.py
+++ b/flake8_nb/flake8_integration/cli.py
@@ -144,9 +144,16 @@ def hack_config_module() -> None:
     with it with ``"flake8_nb"`` to create our own hacked version and replace
     the references to the original module with the hacked one.
 
-    See: https://github.com/s-weigand/flake8-nb/issues/249
+    See:
+        https://github.com/s-weigand/flake8-nb/issues/249
+        https://github.com/s-weigand/flake8-nb/issues/254
     """
-    hacked_config_source = Path(config.__file__).read_text().replace('"flake8"', '"flake8_nb"')
+    hacked_config_source = (
+        Path(config.__file__)
+        .read_text()
+        .replace('"flake8"', '"flake8_nb"')
+        .replace('".flake8"', '".flake8_nb"')
+    )
     hacked_config_path = Path(__file__).parent / "hacked_config.py"
     hacked_config_path.write_text(hacked_config_source)
 
@@ -154,6 +161,10 @@ def hack_config_module() -> None:
 
     sys.modules["flake8.options.config"] = hacked_config
     aggregator.config = hacked_config
+
+    import flake8.main.application as application_module
+
+    application_module.config = hacked_config
 
 
 class Flake8NbApplication(Application):  # type: ignore[misc]
@@ -183,6 +194,7 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
                 self.parse_configuration_and_cli_legacy  # type: ignore[assignment]
             )
         else:
+            hack_config_module()
             self.register_plugin_options = self.hacked_register_plugin_options
 
     def apply_hacks(self) -> None:
@@ -377,7 +389,6 @@ class Flake8NbApplication(Application):  # type: ignore[misc]
         assert self.plugins is not None
 
         self.apply_hacks()
-        hack_config_module()
 
         self.options = aggregator.aggregate_options(
             self.option_manager,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,15 +34,13 @@ verbose = 1
 
 [tool.coverage.run]
 branch = true
-include = [
-  'flake8_nb/*',
-]
+relative_files = true
 omit = [
   'setup.py',
-  "flake8_nb/__init__.py",
-  "flake8_nb/*/__init__.py",
-  "tests/__init__.py",
-  "*/tests/*",
+  'flake8_nb/__init__.py',
+  'flake8_nb/*/__init__.py',
+  'tests/__init__.py',
+  '*/tests/*',
 # comment the above line if you want to see if all tests did run
   ]
 

--- a/tests/test__main__.py
+++ b/tests/test__main__.py
@@ -1,10 +1,13 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+from _pytest.capture import CaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
 from flake8 import __version__ as flake_version
 
 from flake8_nb import FLAKE8_VERSION_TUPLE
@@ -61,6 +64,36 @@ def test_run_main_use_config(capsys, tmp_path: Path):
     with pytest.raises(SystemExit):
         with pytest.warns(InvalidNotebookWarning):
             main([*argv, TEST_NOTEBOOK_BASE_PATH])
+    captured = capsys.readouterr()
+    result_output = captured.out
+    result_list = result_output.replace("\r", "").split("\n")
+    result_list.remove("")
+    expected_result_path = os.path.join(
+        os.path.dirname(__file__), "data", "expected_output_config_test.txt"
+    )
+    with open(expected_result_path) as result_file:
+        expected_result_list = result_file.readlines()
+    assert len(expected_result_list) == len(result_list)
+    for expected_result in expected_result_list:
+        assert any(result.endswith(expected_result.rstrip("\n")) for result in result_list)
+
+
+@pytest.mark.parametrize("config_file_name", ("setup.cfg", "tox.ini", ".flake8_nb"))
+def test_config_discovered(
+    config_file_name: str, tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+):
+    """Check that config file is discovered."""
+
+    test_config = tmp_path / config_file_name
+    test_config.write_text("[flake8_nb]\nextend-ignore = E231,F401")
+
+    shutil.copytree(TEST_NOTEBOOK_BASE_PATH, tmp_path / "notebooks")
+
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        with pytest.raises(SystemExit):
+            with pytest.warns(InvalidNotebookWarning):
+                main(["flake8_nb"])
     captured = capsys.readouterr()
     result_output = captured.out
     result_list = result_output.replace("\r", "").split("\n")

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ max-line-length = 100
 ;     *.py
 
 [pytest]
-addopts = --cov=flake8_nb --cov-report term --cov-report xml --cov-report html --cov-config pyproject.toml
+addopts = --cov=. --cov-report term --cov-report xml --cov-report html --cov-config=pyproject.toml
 filterwarnings =
     ignore:.*not_a_notebook.ipynb
 
@@ -43,8 +43,8 @@ commands_pre =
   {[testenv]commands_pre}
   {envpython} -m pip install -U -q --force-reinstall git+https://github.com/pycqa/flake8
 commands =
-  {envpython}  -c "import flake8_nb;print('FLAKE8 VERSION: ', flake8_nb.FLAKE8_VERSION_TUPLE)"
-  py.test -vv
+  {envpython} -c "import flake8_nb;print('FLAKE8 VERSION: ', flake8_nb.FLAKE8_VERSION_TUPLE)"
+  {envpython} -m pytest -vv
 
 [testenv:flake8-legacy]
 passenv = *
@@ -52,7 +52,7 @@ commands_pre =
   {[testenv]commands_pre}
   {envpython} -m pip install -U -q 'flake8==3.8.0'
 commands =
-  py.test -vv
+  {envpython} -m pytest -vv
 
 [testenv]
 passenv = *
@@ -60,4 +60,4 @@ install_command=python -m pip install {opts} {packages}
 commands_pre =
   {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
 commands =
-  py.test
+  {envpython} -m pytest

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ max-line-length = 100
 ;     *.py
 
 [pytest]
-addopts = --cov=flake8_nb --cov-report term --cov-report xml --cov-report html --cov-config=pyproject.toml
+addopts = --cov=flake8_nb --cov-report term --cov-report xml --cov-report html --cov-config pyproject.toml
 filterwarnings =
     ignore:.*not_a_notebook.ipynb
 


### PR DESCRIPTION
Besides `"flake8"` being hardcoded in `flake8.options.config` so is the config file name `".flake8"` which needs to be replaces with `".flake8_nb"` to prevent a regression where `".flake8_nb` is ignored.
The other problem with the discovery of config files was that the config discovery happens in `Application.initialize` which means that the runtime module replacement needs to happen before this and the `config` module also needs to be replaced inside of `flake8.main.application`.

closes #254 