### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v2.38.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -40,7 +40,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.6.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
         name: nbstripout no notebook_with_out_flake8_tags
@@ -48,7 +48,7 @@ repos:
         exclude: "not_a_notebook|notebook_with_out_flake8_tags|cell_with_source_string"
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.6.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
         name: nbstripout only notebook_with_out_flake8_tags


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/flake8-nb/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.20.0-py2.py3-none-any.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.5/199.5 kB 5.5 MB/s eta 0:00:00
Collecting importlib-metadata
  Downloading importlib_metadata-4.12.0-py3-none-any.whl (21 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.16.5-py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 76.9 MB/s eta 0:00:00
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 596.3/596.3 kB 7.0 MB/s eta 0:00:00
Collecting identify>=1.0.0
  Downloading identify-2.5.5-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.7/98.7 kB 2.0 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages (from nodeenv>=0.11.1->pre-commit) (47.1.0)
Collecting distlib<1,>=0.3.5
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 6.2 MB/s eta 0:00:00
Collecting platformdirs<3,>=2.4
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting filelock<4,>=3.4.1
  Downloading filelock-3.8.0-py3-none-any.whl (10 kB)
Collecting typing-extensions>=3.6.4
  Downloading typing_extensions-4.3.0-py3-none-any.whl (25 kB)
Collecting zipp>=0.5
  Downloading zipp-3.8.1-py3-none-any.whl (5.6 kB)
Installing collected packages: distlib, zipp, typing-extensions, toml, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, importlib-metadata, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.8.0 identify-2.5.5 importlib-metadata-4.12.0 nodeenv-1.7.0 platformdirs-2.5.2 pre-commit-2.20.0 pyyaml-6.0 toml-0.10.2 typing-extensions-4.3.0 virtualenv-20.16.5 zipp-3.8.1
```



</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... already up to date.
Updating https://github.com/pre-commit/pre-commit ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
already up to date.
Updating https://github.com/MarcoGorelli/absolufy-imports ... already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
updating v2.38.0 -> v2.38.2.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
already up to date.
Updating https://github.com/kynan/nbstripout ... [INFO] Initializing environment for https://github.com/kynan/nbstripout.
updating 0.6.0 -> 0.6.1.
Updating https://github.com/kynan/nbstripout ... updating 0.6.0 -> 0.6.1.
Updating https://github.com/asottile/setup-cfg-fmt ... [INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://github.com/pycqa/flake8 ... [INFO] Initializing environment for https://github.com/pycqa/flake8.
already up to date.
Updating https://github.com/PyCQA/isort ... already up to date.
Updating https://github.com/PyCQA/pydocstyle ... already up to date.
Updating https://github.com/terrencepreilly/darglint ... already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/rstcheck/rstcheck ... [INFO] Initializing environment for https://github.com/rstcheck/rstcheck.
already up to date.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
already up to date.
Updating https://github.com/asottile/yesqa ... [INFO] Initializing environment for https://github.com/asottile/yesqa.
already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.0.
[INFO] Initializing environment for https://github.com/rstcheck/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/kynan/nbstripout.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/rstcheck/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
validate pre-commit manifest.............................................Passed
mypy.....................................................................Passed
absolufy-imports.........................................................Passed
pyupgrade................................................................Passed
black....................................................................Passed
nbstripout no notebook_with_out_flake8_tags..............................Passed
nbstripout only notebook_with_out_flake8_tags............................Passed
setup-cfg-fmt............................................................Passed
prettier.................................................................Passed
flake8...................................................................Passed
isort....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)