### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         args: [--include-version-classifiers]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6 # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.8-for-vscode # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         types_or: [python, pyi]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.3.2
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -62,7 +62,7 @@ repos:
         args: [--include-version-classifiers]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.8-for-vscode # Use the sha or tag you want to point at
+    rev: v3.0.0-alpha.9-for-vscode # Use the sha or tag you want to point at
     hooks:
       - id: prettier
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/flake8-nb/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.21.0-py2.py3-none-any.whl (201 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 201.9/201.9 kB 5.0 MB/s eta 0:00:00
Collecting cfgv>=2.0.0 (from pre-commit)
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting identify>=1.0.0 (from pre-commit)
  Downloading identify-2.5.22-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.8/98.8 kB 10.5 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1 (from pre-commit)
  Downloading nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
Collecting pyyaml>=5.1 (from pre-commit)
  Downloading PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 596.3/596.3 kB 13.4 MB/s eta 0:00:00
Collecting virtualenv>=20.10.0 (from pre-commit)
  Downloading virtualenv-20.22.0-py3-none-any.whl (3.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.2/3.2 MB 25.8 MB/s eta 0:00:00
Collecting importlib-metadata (from pre-commit)
  Downloading importlib_metadata-6.6.0-py3-none-any.whl (22 kB)
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.7.16/x64/lib/python3.7/site-packages (from nodeenv>=0.11.1->pre-commit) (47.1.0)
Collecting distlib<1,>=0.3.6 (from virtualenv>=20.10.0->pre-commit)
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 38.3 MB/s eta 0:00:00
Collecting filelock<4,>=3.11 (from virtualenv>=20.10.0->pre-commit)
  Downloading filelock-3.12.0-py3-none-any.whl (10 kB)
Collecting platformdirs<4,>=3.2 (from virtualenv>=20.10.0->pre-commit)
  Downloading platformdirs-3.2.0-py3-none-any.whl (14 kB)
Collecting zipp>=0.5 (from importlib-metadata->pre-commit)
  Downloading zipp-3.15.0-py3-none-any.whl (6.8 kB)
Collecting typing-extensions>=3.6.4 (from importlib-metadata->pre-commit)
  Downloading typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Installing collected packages: distlib, zipp, typing-extensions, pyyaml, nodeenv, identify, filelock, cfgv, platformdirs, importlib-metadata, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.12.0 identify-2.5.22 importlib-metadata-6.6.0 nodeenv-1.7.0 platformdirs-3.2.0 pre-commit-2.21.0 pyyaml-6.0 typing-extensions-4.5.0 virtualenv-20.22.0 zipp-3.15.0
```

### stderr:

```Shell
[notice] A new release of pip is available: 22.0.4 -> 23.1.1
[notice] To update, run: pip install --upgrade pip
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... already up to date.
Updating https://github.com/pre-commit/pre-commit ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit.
already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
already up to date.
Updating https://github.com/MarcoGorelli/absolufy-imports ... already up to date.
Updating https://github.com/asottile/pyupgrade ... already up to date.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
already up to date.
Updating https://github.com/kynan/nbstripout ... already up to date.
Updating https://github.com/kynan/nbstripout ... already up to date.
Updating https://github.com/asottile/setup-cfg-fmt ... already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
updating v3.0.0-alpha.6 -> v3.0.0-alpha.8-for-vscode.
Updating https://github.com/pycqa/flake8 ... already up to date.
Updating https://github.com/PyCQA/isort ... already up to date.
Updating https://github.com/PyCQA/pydocstyle ... already up to date.
Updating https://github.com/terrencepreilly/darglint ... already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/rstcheck/rstcheck ... [INFO] Initializing environment for https://github.com/rstcheck/rstcheck.
already up to date.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/codespell-project/codespell ... [INFO] Initializing environment for https://github.com/codespell-project/codespell.
already up to date.
Updating https://github.com/asottile/yesqa ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.8-for-vscode.
[INFO] Initializing environment for https://github.com/rstcheck/rstcheck:sphinx.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/runner/.cache/pre-commit/repot6midmq_/py_env-python3.7/bin/python', '-mpip', 'install', '.')
return code: 1
stdout:
    Processing /home/runner/.cache/pre-commit/repot6midmq_
      Preparing metadata (setup.py): started
      Preparing metadata (setup.py): finished with status 'done'
    Collecting cfgv>=2.0.0 (from pre-commit==3.2.2)
      Using cached cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
    Collecting identify>=1.0.0 (from pre-commit==3.2.2)
      Using cached identify-2.5.22-py2.py3-none-any.whl (98 kB)
    Collecting nodeenv>=0.11.1 (from pre-commit==3.2.2)
      Using cached nodeenv-1.7.0-py2.py3-none-any.whl (21 kB)
    Collecting pyyaml>=5.1 (from pre-commit==3.2.2)
      Using cached PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (596 kB)
    Collecting virtualenv>=20.10.0 (from pre-commit==3.2.2)
      Using cached virtualenv-20.22.0-py3-none-any.whl (3.2 MB)
    INFO: pip is looking at multiple versions of pre-commit to determine which version is compatible with other requirements. This could take a while.
    
stderr:
    ERROR: Package 'pre-commit' requires a different Python: 3.7.16 not in '>=3.8'
    
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)