### PR TITLE
Fixes build for Readthedocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 formats: all
 
 build:
-  image: latest
+  os: ubuntu-lts-latest
 
 python:
   version: 3.8

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,9 +4,10 @@ formats: all
 
 build:
   os: ubuntu-lts-latest
+  tools:
+    python: "3.8"
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -7,6 +7,10 @@ build:
   tools:
     python: "3.8"
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
Closes #332.

## Summary by Sourcery

Build:
- Switch Read the Docs build configuration from the deprecated image setting to the os: ubuntu-lts-latest setting.